### PR TITLE
Trigger workflow when PR is raised

### DIFF
--- a/.github/workflows/readme_sync.yaml
+++ b/.github/workflows/readme_sync.yaml
@@ -1,5 +1,7 @@
 name: sync_it
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch
 
 permissions:
@@ -12,6 +14,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
   
       - name: Store header section
         run: |
@@ -76,7 +81,7 @@ jobs:
             echo "No changes in README.md, skipping commit."
           else
             git add README.md
-            git commit -m "Update README.md with companies list"
+            git commit -m "chore:Update README.md with companies list"
             git push
           fi
         


### PR DESCRIPTION
- Modified workflow to run the README update action when PR is opened as a chore commit under the PR itself.
-  Possible improvements: 
   - Can squash the commit to prevent the chore from cluttering the commit history.
- Possible alternatives:
   - Run the workflow after the merge commit is made on main and make the workflow commit as part of a separate branch and merge automatically.
   - Run the workflow every night, raise a PR and merge it automatically, instead of on every PR or every merge.